### PR TITLE
Using OIDC authentication for Github action deployment

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -14,6 +14,10 @@ env:
   TG_SRC_PATH: terraform
   TFC_WORKSPACE: prod
 
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read  # This is required for actions/checkout
+
 jobs:
   manual_approval:
     name: Manual approval request
@@ -32,6 +36,7 @@ jobs:
   
   terraform_plan:
     name: Terraform plan production
+    environment: prod
     runs-on: ubuntu-22.04
 
     steps:
@@ -43,10 +48,15 @@ jobs:
       - name: set environment
         run: echo "APP_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
         
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.TERRAFORM_DEPLOY_ROLE_ARN }}
+          aws-region: ca-central-1
+
       - uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: ${{ env.TF_VERSION }}
-          cli_config_credentials_token: ${{ secrets.TFC_TEAM_TOKEN }}
 
       - uses: peter-murray/terragrunt-github-action@v1.0.0
         with:
@@ -134,6 +144,7 @@ jobs:
 
   tag:
     name: Tagging the Docker image
+    environment: tools
     runs-on: ubuntu-22.04
     needs: manual_approval
 
@@ -141,16 +152,11 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
 
-      - name: Configure AWS credentials
+      - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-duration-seconds: 900
-          role-session-name: startup-sample-project-github-action
-          role-skip-session-tagging: true
+          role-to-assume: ${{ secrets.TERRAFORM_DEPLOY_ROLE_ARN }}
+          aws-region: ca-central-1
           
       - name: Login to Amazon ECR
         uses: aws-actions/amazon-ecr-login@v1
@@ -176,10 +182,15 @@ jobs:
       - name: set environment
         run: echo "APP_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.TERRAFORM_DEPLOY_ROLE_ARN }}
+          aws-region: ca-central-1
+
       - uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: ${{ env.TF_VERSION }}
-          cli_config_credentials_token: ${{ secrets.TFC_TEAM_TOKEN }}
 
       - uses: peter-murray/terragrunt-github-action@v1.0.0
         with:

--- a/.github/workflows/deploy-sandbox-manual.yaml
+++ b/.github/workflows/deploy-sandbox-manual.yaml
@@ -10,6 +10,10 @@ env:
   TG_SRC_PATH: terraform
   TFC_WORKSPACE: sandbox
 
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read  # This is required for actions/checkout
+
 jobs:
   tf_apply:
     name: Deploy sandbox AWS ECR
@@ -22,10 +26,15 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.TERRAFORM_DEPLOY_ROLE_ARN }}
+          aws-region: ca-central-1
+
       - uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: ${{ env.TF_VERSION }}
-          cli_config_credentials_token: ${{ secrets.TFC_TEAM_TOKEN }}
 
       - uses: peter-murray/terragrunt-github-action@v1.0.0
         with:

--- a/.github/workflows/deploy-sandbox.yaml
+++ b/.github/workflows/deploy-sandbox.yaml
@@ -16,6 +16,10 @@ env:
   TG_SRC_PATH: terraform
   TFC_WORKSPACE: sandbox
 
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read  # This is required for actions/checkout
+
 jobs:
   tf_apply:
     name: Deploy sandbox AWS ECR
@@ -28,10 +32,15 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.TERRAFORM_DEPLOY_ROLE_ARN }}
+          aws-region: ca-central-1
+
       - uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: ${{ env.TF_VERSION }}
-          cli_config_credentials_token: ${{ secrets.TFC_TEAM_TOKEN }}
 
       - uses: peter-murray/terragrunt-github-action@v1.0.0
         with:

--- a/.github/workflows/deploy-test.yaml
+++ b/.github/workflows/deploy-test.yaml
@@ -13,25 +13,25 @@ env:
   TG_SRC_PATH: terraform
   TFC_WORKSPACE: test
 
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read  # This is required for actions/checkout
+
 jobs:
   tag:
     name: Tagging the Docker image
+    environment: tools
     runs-on: ubuntu-22.04
 
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
 
-      - name: Configure AWS credentials
+      - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-duration-seconds: 900
-          role-session-name: startup-sample-project-github-action
-          role-skip-session-tagging: true
+          role-to-assume: ${{ secrets.TERRAFORM_DEPLOY_ROLE_ARN }}
+          aws-region: ca-central-1
           
       - name: Login to Amazon ECR
         uses: aws-actions/amazon-ecr-login@v1
@@ -56,11 +56,16 @@ jobs:
 
       - name: set environment
         run: echo "APP_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.TERRAFORM_DEPLOY_ROLE_ARN }}
+          aws-region: ca-central-1
         
       - uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: ${{ env.TF_VERSION }}
-          cli_config_credentials_token: ${{ secrets.TFC_TEAM_TOKEN }}
 
       - uses: peter-murray/terragrunt-github-action@v1.0.0
         with:

--- a/.github/workflows/deploy-tools-manual.yaml
+++ b/.github/workflows/deploy-tools-manual.yaml
@@ -9,9 +9,14 @@ env:
   TG_SRC_PATH: terraform
   TFC_WORKSPACE: tools
 
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read  # This is required for actions/checkout
+
 jobs:
   cd:
     name: cd
+    environment: tools
     runs-on: ubuntu-22.04
 
     steps:
@@ -20,10 +25,15 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.TERRAFORM_DEPLOY_ROLE_ARN }}
+          aws-region: ca-central-1
+
       - uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: ${{ env.TF_VERSION }}
-          cli_config_credentials_token: ${{ secrets.TFC_TEAM_TOKEN }}
 
       - uses: peter-murray/terragrunt-github-action@v1.0.0
         with:

--- a/.github/workflows/destroy-env.yml
+++ b/.github/workflows/destroy-env.yml
@@ -15,6 +15,10 @@ env:
   TG_VERSION: 0.37.1
   TG_SRC_PATH: terraform
 
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read  # This is required for actions/checkout
+
 jobs:
   tf_destroy:
     name: Destroy the selected environment
@@ -27,10 +31,15 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.TERRAFORM_DEPLOY_ROLE_ARN }}
+          aws-region: ca-central-1
+
       - uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: ${{ env.TF_VERSION }}
-          cli_config_credentials_token: ${{ secrets.TFC_TEAM_TOKEN }}
 
       - uses: peter-murray/terragrunt-github-action@v1.0.0
         with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,6 +21,10 @@ env:
   TG_SRC_PATH: terraform
   TFC_WORKSPACE: dev
 
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read  # This is required for actions/checkout
+
 jobs:
   docker_build:
     name: docker build
@@ -64,6 +68,7 @@ jobs:
 
   terrafrom_plan:
     name: terraform plan
+    environment: dev
     runs-on: ubuntu-22.04
 
     steps:
@@ -72,10 +77,15 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.TERRAFORM_DEPLOY_ROLE_ARN }}
+          aws-region: ca-central-1
+
       - uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: ${{ env.TF_VERSION }}
-          cli_config_credentials_token: ${{ secrets.TFC_TEAM_TOKEN }}
 
       - uses: peter-murray/terragrunt-github-action@v1.0.0
         with:

--- a/.github/workflows/push-manual.yaml
+++ b/.github/workflows/push-manual.yaml
@@ -12,25 +12,25 @@ env:
   TG_SRC_PATH: terraform
   TFC_WORKSPACE: dev
 
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read  # This is required for actions/checkout
+
 jobs:
   docker_push:
     name: docker push
+    environment: tools
     runs-on: ubuntu-22.04
 
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
 
-      - name: Configure AWS credentials
+      - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-duration-seconds: 900
-          role-session-name: startup-sample-project-github-action
-          role-skip-session-tagging: true
+          role-to-assume: ${{ secrets.TERRAFORM_DEPLOY_ROLE_ARN }}
+          aws-region: ca-central-1
 
       - name: Login to Amazon ECR
         id: login-ecr
@@ -82,10 +82,15 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.TERRAFORM_DEPLOY_ROLE_ARN }}
+          aws-region: ca-central-1
+
       - uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: ${{ env.TF_VERSION }}
-          cli_config_credentials_token: ${{ secrets.TFC_TEAM_TOKEN }}
 
       - uses: peter-murray/terragrunt-github-action@v1.0.0
         with:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -21,25 +21,25 @@ env:
   TG_SRC_PATH: terraform
   TFC_WORKSPACE: dev
 
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read  # This is required for actions/checkout
+
 jobs:
   docker_push:
     name: docker push
+    environment: tools
     runs-on: ubuntu-22.04
 
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
 
-      - name: Configure AWS credentials
+      - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-duration-seconds: 900
-          role-session-name: startup-sample-project-github-action
-          role-skip-session-tagging: true
+          role-to-assume: ${{ secrets.TERRAFORM_DEPLOY_ROLE_ARN }}
+          aws-region: ca-central-1
 
       - name: Login to Amazon ECR
         id: login-ecr
@@ -91,10 +91,15 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.TERRAFORM_DEPLOY_ROLE_ARN }}
+          aws-region: ca-central-1
+
       - uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: ${{ env.TF_VERSION }}
-          cli_config_credentials_token: ${{ secrets.TFC_TEAM_TOKEN }}
 
       - uses: peter-murray/terragrunt-github-action@v1.0.0
         with:

--- a/terraform/dev/terragrunt.hcl
+++ b/terraform/dev/terragrunt.hcl
@@ -1,7 +1,5 @@
 terraform {
-  # source = "git::https://github.com/bcgov/startup-sample-project-aws-containers-terraform-modules.git//?ref=v0.1"
-  source = "git::https://github.com/kdesao-devops/startup-sample-project-aws-containers-terraform-modules.git//?ref=OIDC_integration"
-
+  source = "git::https://github.com/bcgov/startup-sample-project-aws-containers-terraform-modules.git//?ref=v0.2"
 }
 
 include {

--- a/terraform/dev/terragrunt.hcl
+++ b/terraform/dev/terragrunt.hcl
@@ -1,5 +1,7 @@
 terraform {
-  source = "git::https://github.com/bcgov/startup-sample-project-aws-containers-terraform-modules.git//?ref=v0.1"
+  # source = "git::https://github.com/bcgov/startup-sample-project-aws-containers-terraform-modules.git//?ref=v0.1"
+  source = "git::https://github.com/kdesao-devops/startup-sample-project-aws-containers-terraform-modules.git//?ref=OIDC_integration"
+
 }
 
 include {

--- a/terraform/prod/terragrunt.hcl
+++ b/terraform/prod/terragrunt.hcl
@@ -6,21 +6,3 @@ terraform {
 include {
   path = find_in_parent_folders()
 }
-
-locals {
-  project = get_env("LICENSE_PLATE")
-}
-
-generate "prod_tfvars" {
-  path              = "prod.auto.tfvars"
-  if_exists         = "overwrite"
-  disable_signature = true
-  contents          = <<-EOF
-service_names = ["ssp"]
-
-alb_name = "default"
-cloudfront = true
-
-cloudfront_origin_domain = "startup-sample-project.${local.project}-prod.lz1.nimbus.cloud.gov.bc.ca"
-EOF
-}

--- a/terraform/prod/terragrunt.hcl
+++ b/terraform/prod/terragrunt.hcl
@@ -1,5 +1,6 @@
 terraform {
-  source = "git::https://github.com/bcgov/startup-sample-project-aws-containers-terraform-modules.git//?ref=v0.0.4"
+  # source = "git::https://github.com/bcgov/startup-sample-project-aws-containers-terraform-modules.git//?ref=v0.0.4"
+  source = "git::https://github.com/kdesao-devops/startup-sample-project-aws-containers-terraform-modules.git//.?ref=OIDC_integration"
 }
 
 include {

--- a/terraform/prod/terragrunt.hcl
+++ b/terraform/prod/terragrunt.hcl
@@ -1,6 +1,5 @@
 terraform {
-  # source = "git::https://github.com/bcgov/startup-sample-project-aws-containers-terraform-modules.git//?ref=v0.0.4"
-  source = "git::https://github.com/kdesao-devops/startup-sample-project-aws-containers-terraform-modules.git//.?ref=OIDC_integration"
+  source = "git::https://github.com/bcgov/startup-sample-project-aws-containers-terraform-modules.git//?ref=v0.2"
 }
 
 include {

--- a/terraform/prod/terragrunt.hcl
+++ b/terraform/prod/terragrunt.hcl
@@ -6,3 +6,21 @@ terraform {
 include {
   path = find_in_parent_folders()
 }
+
+locals {
+  project = get_env("LICENSE_PLATE")
+}
+
+generate "prod_tfvars" {
+  path              = "prod.auto.tfvars"
+  if_exists         = "overwrite"
+  disable_signature = true
+  contents          = <<-EOF
+service_names = ["ssp"]
+
+alb_name = "default"
+cloudfront = true
+
+cloudfront_origin_domain = "startup-sample-project.${local.project}-prod.lz1.nimbus.cloud.gov.bc.ca"
+EOF
+}

--- a/terraform/test/terragrunt.hcl
+++ b/terraform/test/terragrunt.hcl
@@ -1,5 +1,6 @@
 terraform {
-  source = "git::https://github.com/bcgov/startup-sample-project-aws-containers-terraform-modules.git//?ref=v0.0.4"
+  # source = "git::https://github.com/bcgov/startup-sample-project-aws-containers-terraform-modules.git//?ref=v0.0.4"
+  source = "git::https://github.com/kdesao-devops/startup-sample-project-aws-containers-terraform-modules.git//.?ref=OIDC_integration"
 }
 
 include {

--- a/terraform/test/terragrunt.hcl
+++ b/terraform/test/terragrunt.hcl
@@ -17,10 +17,5 @@ generate "test_tfvars" {
   disable_signature = true
   contents          = <<-EOF
 service_names = ["ssp"]
-
-alb_name = "default"
-cloudfront = true
-
-cloudfront_origin_domain = "startup-sample-project.${local.project}-test.lz1.nimbus.cloud.gov.bc.ca"
 EOF
 }

--- a/terraform/test/terragrunt.hcl
+++ b/terraform/test/terragrunt.hcl
@@ -7,11 +7,20 @@ include {
   path = find_in_parent_folders()
 }
 
+locals {
+  project = get_env("LICENSE_PLATE")
+}
+
 generate "test_tfvars" {
   path              = "test.auto.tfvars"
   if_exists         = "overwrite"
   disable_signature = true
   contents          = <<-EOF
 service_names = ["ssp"]
+
+alb_name = "default"
+cloudfront = true
+
+cloudfront_origin_domain = "startup-sample-project.${local.project}-test.lz1.nimbus.cloud.gov.bc.ca"
 EOF
 }

--- a/terraform/test/terragrunt.hcl
+++ b/terraform/test/terragrunt.hcl
@@ -1,6 +1,5 @@
 terraform {
-  # source = "git::https://github.com/bcgov/startup-sample-project-aws-containers-terraform-modules.git//?ref=v0.0.4"
-  source = "git::https://github.com/kdesao-devops/startup-sample-project-aws-containers-terraform-modules.git//.?ref=OIDC_integration"
+  source = "git::https://github.com/bcgov/startup-sample-project-aws-containers-terraform-modules.git//?ref=v0.2"
 }
 
 include {

--- a/terraform/tools/terragrunt.hcl
+++ b/terraform/tools/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "git::https://github.com/BCDevOps/terraform-octk-aws-workload-ecr.git//.?ref=v0.0.3"
+  source = "git::https://github.com/kdesao-devops/terraform-octk-aws-workload-ecr.git//.?ref=OIDC_integration"
 }
 
 include {

--- a/terraform/tools/terragrunt.hcl
+++ b/terraform/tools/terragrunt.hcl
@@ -1,4 +1,5 @@
 terraform {
+  # source = "git::https://github.com/bcgov/terraform-octk-aws-workload-ecr.git//?ref=v0.0.4"
   source = "git::https://github.com/kdesao-devops/terraform-octk-aws-workload-ecr.git//.?ref=OIDC_integration"
 }
 

--- a/terraform/tools/terragrunt.hcl
+++ b/terraform/tools/terragrunt.hcl
@@ -2,10 +2,11 @@ terraform {
   source = "git::https://github.com/BCDevOps/terraform-octk-aws-workload-ecr.git//.?ref=v0.0.3"
 }
 
+include {
+  path = find_in_parent_folders()
+}
+
 locals {
-  tfc_hostname     = "app.terraform.io"
-  tfc_organization = "bcgov"
-  project          = get_env("LICENSE_PLATE")
   environment      = reverse(split("/", get_terragrunt_dir()))[0]
   read_principals  = get_env("AWS_ACCOUNTS_ECR_READ_ACCESS", "")
 }
@@ -18,35 +19,5 @@ generate "tfvars" {
   contents          = <<-EOF
 repository_names = ["ssp"]
 read_principals = ${local.read_principals}
-EOF
-}
-
-generate "remote_state" {
-  path      = "backend.tf"
-  if_exists = "overwrite"
-  contents  = <<EOF
-terraform {
-  backend "remote" {
-    hostname = "${local.tfc_hostname}"
-    organization = "${local.tfc_organization}"
-    workspaces {
-      name = "${local.project}-${local.environment}"
-    }
-  }
-}
-EOF
-}
-
-generate "provider" {
-  path      = "provider.tf"
-  if_exists = "overwrite"
-  contents  = <<EOF
-provider "aws" {
-  region  = var.aws_region
-
-  assume_role {
-    role_arn = "arn:aws:iam::$${var.target_aws_account_id}:role/BCGOV_$${var.target_env}_Automation_Admin_Role"
-  }
-}
 EOF
 }

--- a/terraform/tools/terragrunt.hcl
+++ b/terraform/tools/terragrunt.hcl
@@ -1,6 +1,5 @@
 terraform {
-  # source = "git::https://github.com/bcgov/terraform-octk-aws-workload-ecr.git//?ref=v0.0.4"
-  source = "git::https://github.com/kdesao-devops/terraform-octk-aws-workload-ecr.git//.?ref=OIDC_integration"
+  source = "git::https://github.com/bcgov/terraform-octk-aws-workload-ecr.git//?ref=v0.0.4"
 }
 
 include {


### PR DESCRIPTION
# Context
We want to use the OIDC module to authenticate the Github action without using terraform cloud.

## Dependancies
- [x] Merging and creating the tag v0.2 for this [PR](https://github.com/bcgov/startup-sample-project-aws-containers-terraform-modules/pull/8)
- [x] Merging and creating the tag v0.0.4 for this [PR](https://github.com/BCDevOps/terraform-octk-aws-workload-ecr/pull/1)

## Changes
- [x] add Github action permissions
- [x] improve Github environment management
- [x] Introduce `secrets.TERRAFORM_DEPLOY_ROLE_ARN` for each env
- [x] Removing `secrets.TFC_TEAM_TOKEN`

## Test
- [x] [Deploy](https://github.com/kdesao-devops/startup-sample-project-aws-containers/actions/runs/3441408186) on dev env on lz0
- [x] [Deploy](https://github.com/kdesao-devops/startup-sample-project-aws-containers/actions/runs/3441285834) on tools on lz0
- [ ] [Deploy](https://github.com/kdesao-devops/startup-sample-project-aws-containers/actions/runs/3441410270) on test (Authentication success, Failed due to the default alb not existing in the account)
- [ ] [Deploy](https://github.com/kdesao-devops/startup-sample-project-aws-containers/actions/runs/3441469044) on Prod (Authentication success, Failed due to a bug in the [manual-approval open issue](https://github.com/gruntwork-io/terragrunt/issues/1960))
- [x] [Destroy](https://github.com/kdesao-devops/startup-sample-project-aws-containers/actions/runs/3473083925) dev